### PR TITLE
v0.5.1

### DIFF
--- a/Mod/Extensions/ListExtensions.cs
+++ b/Mod/Extensions/ListExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mod.Extensions
+{
+    public static class ListExtensions
+    {
+        /// <summary>
+        /// Return a randomly selected item from the list.
+        /// </summary>
+        /// <param name="list">The list to select from.</param>
+        /// <returns>A randomly selected item from the list or throws if empty/null.</returns>
+        public static T GetRandom<T>(this IList<T> list)
+        {
+            if (list == null || list.Count == 0)
+            {
+                throw new InvalidOperationException("Cannot select random element from a null or empty list.");
+            }
+
+            return list[UnityEngine.Random.Range(0, maxExclusive: list.Count)];
+        }
+    }
+}

--- a/Mod/Mappings/SupportedMappings.cs
+++ b/Mod/Mappings/SupportedMappings.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mod.Mappings
+{
+    public static class SupportedMappings
+    {
+        public static readonly List<GlyphType> CurseTypes = new()
+        {
+            GlyphType.Blank,
+            GlyphType.Chess,
+            GlyphType.Currency,
+            GlyphType.Number,
+            GlyphType.Fraction,
+            GlyphType.BespokeCard,
+            GlyphType.ScatteredItem
+        };
+
+        public static readonly List<TileType> ColourTypes = new()
+        {
+            TileType.Blue,
+            TileType.Normal,
+            TileType.Red,
+            TileType.Shiny,
+            TileType.Void,
+        };
+    }
+}

--- a/Mod/Mod.cs
+++ b/Mod/Mod.cs
@@ -232,7 +232,7 @@ namespace Modd
         /// <param name="args">Any additional arguments.</param>
         public void TryCheckEncounterLocations(string action, Player player, List<BossModifier>? bossModifiers = null, object args = null)
         {
-            foreach (LocationCriteria criteria in RelevantLocations.Where(l => l.OnEncounterAction?.Invoke(action, player, bossModifiers, args) == true))
+            foreach (LocationCriteria criteria in RelevantLocations.Where(l => l.OnEncounterAction?.Invoke(action, player, bossModifiers ?? new List<BossModifier>(), args ?? string.Empty) == true))
             {
                 TryCheckLocation(criteria.LocationName);
             }

--- a/Mod/Mod.cs
+++ b/Mod/Mod.cs
@@ -441,7 +441,7 @@ namespace Modd
             return !ArchipelagoHelper.SlotData.ShuffleItemRarities ||
                 rarity switch
                 {
-                    ItemRarity.Rare | ItemRarity.Legendary => ArchipelagoHelper.HasReceivedItem("Progressive Item Rarity", (int)rarity),
+                    ItemRarity.Rare or ItemRarity.Legendary => ArchipelagoHelper.HasReceivedItem("Progressive Item Rarity", (int)rarity),
                     _ => true
                 };
         }

--- a/Mod/Mod.cs
+++ b/Mod/Mod.cs
@@ -22,7 +22,7 @@ using UnityEngine.Windows;
 
 namespace Modd
 {
-    [BepInPlugin("archipelago", "Cursed Words Archipelago", "0.5.0")]
+    [BepInPlugin("archipelago", "Cursed Words Archipelago", "0.5.1")]
     public class CursedWordsArchipelago : BaseUnityPlugin
     {
         #region Private Properties

--- a/Mod/Mod.csproj
+++ b/Mod/Mod.csproj
@@ -5,6 +5,7 @@
 		<AssemblyName>Mod</AssemblyName>
 		<GamePath>D:\SteamLibrary\steamapps\common\Cursed Words</GamePath>
 		<BepInExPath>$(GamePath)\BepInEx</BepInExPath>
+		<LangVersion>10.0</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 	  <None Remove="Sprites\archipelago.png" />

--- a/Mod/Patches/InventoryVisualController.cs
+++ b/Mod/Patches/InventoryVisualController.cs
@@ -1,5 +1,8 @@
 ﻿using HarmonyLib;
+using Mod.Classes;
 using Modd;
+using System;
+using System.Reflection;
 
 namespace Mod.Patches
 {
@@ -31,6 +34,28 @@ namespace Mod.Patches
 
             // Send check for destroying tile
             CursedWordsArchipelago.Instance.TryCheckGenericLocations("destroy_tile");
+        }
+
+        /// <summary>
+        /// When selling an item, ensure the 'Unicorn' item ignores AP Padlocks.
+        /// </summary>
+        [HarmonyPatch]
+        private static class Unicorn_OnSell_Patch
+        {
+            static MethodBase TargetMethod()
+            {
+                Type displayClassType = AccessTools.Inner(typeof(InventoryVisualController), "<>c");
+                return AccessTools.Method(displayClassType, "<OnItemSellButtonClicked>b__80_7");
+            }
+
+            [HarmonyPostfix]
+            private static void Unicorn_OnSell_Postfix(Item sticker, ref bool __result)
+            {
+                if (sticker is APStampPadlock or APStickerPadlock)
+                {
+                    __result = false;
+                }
+            }
         }
     }
 }

--- a/Mod/Patches/MusicController.cs
+++ b/Mod/Patches/MusicController.cs
@@ -67,6 +67,9 @@ namespace Mod.Patches
             // Attempt to send run win check (Stage 5-3)
             Player player = GameStatics.GetPlayer();
 
+            Logger.LogInfo($"Current run stage: {player.CurrentRunProgress.CurrentStage}");
+            Logger.LogInfo($"Current node type: {player.CurrentRunProgress.CurrentNodeType}");
+
             // Attempt to send run win check (Stage 6-3)
             CursedWordsArchipelago.Instance.TryCheckEncounterLocations("win_encounter", player);
 

--- a/Mod/Patches/MusicController.cs
+++ b/Mod/Patches/MusicController.cs
@@ -67,9 +67,6 @@ namespace Mod.Patches
             // Attempt to send run win check (Stage 5-3)
             Player player = GameStatics.GetPlayer();
 
-            Logger.LogInfo($"Current run stage: {player.CurrentRunProgress.CurrentStage}");
-            Logger.LogInfo($"Current node type: {player.CurrentRunProgress.CurrentNodeType}");
-
             // Attempt to send run win check (Stage 6-3)
             CursedWordsArchipelago.Instance.TryCheckEncounterLocations("win_encounter", player);
 

--- a/Mod/Patches/SaveManager.cs
+++ b/Mod/Patches/SaveManager.cs
@@ -74,7 +74,7 @@ namespace Mod.Patches
         [HarmonyPrefix]
         public static bool IsItemUnlockedOverload_Prefix(Type itemType, ref bool __result)
         {
-            return IsItemUnlockedOverload_Prefix(itemType, ref __result);
+            return IsItemUnlocked_Prefix(itemType, ref __result);
         }
 
         /// <summary>

--- a/Mod/Patches/ScatteredItemPools.cs
+++ b/Mod/Patches/ScatteredItemPools.cs
@@ -18,7 +18,7 @@ namespace Mod.Patches
         /// </summary>
         [HarmonyPatch("GetRarityWeightedItem")]
         [HarmonyPostfix]
-        public static bool GetRarityWeightedItem_Postfix(ref Item __result)
+        private static void GetRarityWeightedItem_Postfix(List<Item> items, ref Item __result)
         {
             Logger.LogInfo($"{nameof(ScatteredItemPools)}.GetRarityWeightedItem postfix!");
 
@@ -34,8 +34,6 @@ namespace Mod.Patches
                     __result = ScatteredItemPools.GetRandomItem();
                 }
             }
-
-            return false;
         }
     }
 }

--- a/Mod/Patches/ScatteredItemPools.cs
+++ b/Mod/Patches/ScatteredItemPools.cs
@@ -1,0 +1,41 @@
+﻿using HarmonyLib;
+using Mod.Helpers;
+using Mod.Mappings;
+using Modd;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.SceneManagement;
+
+namespace Mod.Patches
+{
+    [HarmonyPatch(typeof(ScatteredItemPools))]
+    internal class ScatteredItemPools_Patches : PatchBase
+    {
+        /// <summary>
+        /// Override fallback to Graduation Cap for Scattered Items, as it isn't in the emoji dictionary and crashes.
+        /// (I spoke to Skyeward about this, but this scenario should never happen in Vanilla!)
+        /// </summary>
+        [HarmonyPatch("GetRarityWeightedItem")]
+        [HarmonyPostfix]
+        public static bool GetRarityWeightedItem_Postfix(ref Item __result)
+        {
+            Logger.LogInfo($"{nameof(ScatteredItemPools)}.GetRarityWeightedItem postfix!");
+
+            // If graduation cap, override it
+            if (__result is GraduationCap)
+            {
+                // Try to replace with generic mult item
+                __result = ScatteredItemPools.GetRandomGenericMultItem();
+
+                // If it's STILL a graduation cap, try any random item
+                if (__result is GraduationCap)
+                {
+                    __result = ScatteredItemPools.GetRandomItem();
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Mod/Patches/Tile.cs
+++ b/Mod/Patches/Tile.cs
@@ -1,5 +1,7 @@
 ﻿using HarmonyLib;
+using Mod.Extensions;
 using Mod.Helpers;
+using Mod.Mappings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,6 +14,70 @@ namespace Mod.Patches
     [HarmonyPatch(typeof(Tile))]
     internal class Tile_Patches : PatchBase
     {
+        /// <summary>
+        /// Override random curses to ensure all supported curse types are selected from.
+        /// (Items like Amphora would only produce Blank or Currency tiles)
+        /// </summary>
+        [HarmonyPatch(nameof(Tile.RandomlyCurseTile))]
+        [HarmonyPrefix]
+        private static bool RandomlyCurseTile_Prefix(Tile __instance)
+        {
+            Logger.LogInfo($"{nameof(Tile)}.{nameof(Tile.RandomlyCurseTile)} prefix!");
+
+            // Select random supported curse type and apply it
+            GlyphType curseType = SupportedMappings.CurseTypes.GetRandom();
+            switch (curseType)
+            {
+                case GlyphType.BespokeCard:
+                    {
+                        __instance.SetGlyphType(curseType);
+
+                        if (UnityEngine.Random.Range(0, 10) == 0)
+                        {
+                            __instance.SetSuit(Suit.Joker);
+                        }
+                    }
+                    break;
+
+                case GlyphType.Blank:
+                    // Do nothing
+                    break;
+
+                case GlyphType.Chess:
+                    __instance.SetToRandomChessPiece();
+                    break;
+
+                case GlyphType.Currency:
+                    __instance.SetToRandomCurrency();
+                    break;
+
+                case GlyphType.Fraction:
+                    __instance.SetToRandomFraction();
+                    break;
+
+                case GlyphType.Number:
+                    __instance.SetToRandomNumber();
+                    break;
+
+                case GlyphType.ScatteredItem:
+                    __instance.SetToRandomItem();
+                    break;
+
+                default:
+                    Logger.LogWarning($"Random curse type: {curseType} is not currently supported, defaulting to letter.");
+                    __instance.SetToRandomLetter();
+                    break;
+            }
+
+            // if not joker, apply a random suit
+            if (__instance.GetSuit() is Suit.None)
+            {
+                __instance.SetSuit(PlayingCardUtility.GetRandomCardSuit());
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Prevent chess piece being set if tile type not yet received.
         /// </summary>

--- a/Mod/Patches/Tile.cs
+++ b/Mod/Patches/Tile.cs
@@ -20,59 +20,70 @@ namespace Mod.Patches
         /// </summary>
         [HarmonyPatch(nameof(Tile.RandomlyCurseTile))]
         [HarmonyPrefix]
-        private static bool RandomlyCurseTile_Prefix(Tile __instance)
+        private static bool RandomlyCurseTile_Prefix(ref Tile tile, bool isAllowingScatteredItems)
         {
             Logger.LogInfo($"{nameof(Tile)}.{nameof(Tile.RandomlyCurseTile)} prefix!");
 
+            // Get supported curse types (excluding scattered item if not allowing)
+            List<GlyphType> curseTypes = SupportedMappings.CurseTypes
+                .Where(ct => isAllowingScatteredItems || ct != GlyphType.ScatteredItem)
+                .ToList();
+
             // Select random supported curse type and apply it
-            GlyphType curseType = SupportedMappings.CurseTypes.GetRandom();
+            GlyphType curseType = curseTypes.GetRandom();
             switch (curseType)
             {
                 case GlyphType.BespokeCard:
                     {
-                        __instance.SetGlyphType(curseType);
+                        tile.SetGlyphType(curseType);
 
                         if (UnityEngine.Random.Range(0, 10) == 0)
                         {
-                            __instance.SetSuit(Suit.Joker);
+                            tile.SetSuit(Suit.Joker);
+                        }
+                        else
+                        {
+                            tile.SetToRandomLetter();
                         }
                     }
                     break;
 
                 case GlyphType.Blank:
-                    // Do nothing
+                    tile.SetGlyphType(curseType);
                     break;
 
                 case GlyphType.Chess:
-                    __instance.SetToRandomChessPiece();
+                    tile.SetChessPiece(ChessPieces.GetRandomChessPiece());
                     break;
 
                 case GlyphType.Currency:
-                    __instance.SetToRandomCurrency();
+                    tile.SetLetter(Currency.GetRandomCurrency());
+                    tile.SetGlyphType(curseType);
                     break;
 
                 case GlyphType.Fraction:
-                    __instance.SetToRandomFraction();
+                    string randomFraction = Alphabet.GetRandomFraction();
+                    tile.SetFractionNumbers(Alphabet.GetFractionNumbers(randomFraction));
                     break;
 
                 case GlyphType.Number:
-                    __instance.SetToRandomNumber();
+                    tile.SetNumber(UnityEngine.Random.Range(1, 9));
                     break;
 
                 case GlyphType.ScatteredItem:
-                    __instance.SetToRandomItem();
+                    tile.SetScatteredItem(ScatteredItemPools.GetRandomItem());
                     break;
 
                 default:
                     Logger.LogWarning($"Random curse type: {curseType} is not currently supported, defaulting to letter.");
-                    __instance.SetToRandomLetter();
+                    tile.SetToRandomLetter();
                     break;
             }
 
             // if not joker, apply a random suit
-            if (__instance.GetSuit() is Suit.None)
+            if (tile.GetSuit() is Suit.None)
             {
-                __instance.SetSuit(PlayingCardUtility.GetRandomCardSuit());
+                tile.SetSuit(PlayingCardUtility.GetRandomCardSuit());
             }
 
             return false;


### PR DESCRIPTION
## Fixes
- Fixed `ScatteredItem` crash when item-unlock fallback selects `Graduation Cap`.
- Fixed `Progressive Item Rarity` item not correctly gating item rarities in the shop. (#63)
- Fixed curse-scattering items to scatter all supported curse types instead of waiting for bulk unlocks. (#57)
- Fixed issue causing a crash when beating Michael (#62)
- Fixed issue causing `Unicorn` to select the AP Padlock items (#60)